### PR TITLE
Improve how texture buffers are assigned texture units.

### DIFF
--- a/include/FLAMEGPU_Visualisation.h
+++ b/include/FLAMEGPU_Visualisation.h
@@ -16,8 +16,8 @@ class FLAMEGPU_Visualisation {
  public:
     explicit FLAMEGPU_Visualisation(const ModelConfig &modelcfg);
     ~FLAMEGPU_Visualisation();
-    void addAgentState(const std::string &agent_name, const std::string &state_name, const AgentStateConfig &vc) {
-        addAgentState(agent_name.c_str(), state_name.c_str(), vc);
+    void addAgentState(const std::string &agent_name, const std::string &state_name, const AgentStateConfig &vc, bool has_x, bool has_y, bool has_z) {
+        addAgentState(agent_name.c_str(), state_name.c_str(), vc, has_x, has_y, has_z);
     }
     void requestBufferResizes(const std::string &agent_name, const std::string &state_name, const unsigned int buffLen) {
         requestBufferResizes(agent_name.c_str(), state_name.c_str(), buffLen);
@@ -47,7 +47,7 @@ class FLAMEGPU_Visualisation {
     bool isRunning() const;
 
  private:
-    void addAgentState(const char *agent_name, const char *state_name, const AgentStateConfig &vc);
+    void addAgentState(const char *agent_name, const char *state_name, const AgentStateConfig &vc, bool has_x = true, bool has_y = true, bool has_z = true);
     void requestBufferResizes(const char *agent_name, const char *state_name, const unsigned int buffLen);
     void updateAgentStateBuffer(const char *agent_name, const char *state_name, const unsigned int buffLen, float *d_x, float *d_y, float *d_z);
     Visualiser *vis = nullptr;

--- a/src/FLAMEGPU_Visualisation.cpp
+++ b/src/FLAMEGPU_Visualisation.cpp
@@ -19,8 +19,8 @@ FLAMEGPU_Visualisation::~FLAMEGPU_Visualisation() {
     if (lock)
         delete lock;
 }
-void FLAMEGPU_Visualisation::addAgentState(const char *agent_name, const char *state_name, const AgentStateConfig &vc) {
-    vis->addAgentState(agent_name, state_name, vc);
+void FLAMEGPU_Visualisation::addAgentState(const char *agent_name, const char *state_name, const AgentStateConfig &vc, bool has_x, bool has_y, bool has_z) {
+    vis->addAgentState(agent_name, state_name, vc, has_x, has_y, has_z);
 }
 void FLAMEGPU_Visualisation::requestBufferResizes(const char *agent_name, const char *state_name, const unsigned int buffLen) {
     vis->requestBufferResizes(agent_name, state_name, buffLen);

--- a/src/Visualiser.h
+++ b/src/Visualiser.h
@@ -40,13 +40,16 @@ class Visualiser : public ViewportExt {
         }
     };
     struct RenderInfo {
-        explicit RenderInfo(const AgentStateConfig &vc)
+        explicit RenderInfo(const AgentStateConfig &vc, bool _has_x, bool _has_y, bool _has_z)
             : config(vc)
-            , tex_unit_offset(3 * instanceCounter++)
+            , tex_unit_offset(0)
             , instanceCount(0)
             , x_var(nullptr)
             , y_var(nullptr)
             , z_var(nullptr)
+            , has_x(_has_x)
+            , has_y(_has_y)
+            , has_z(_has_z)
             , entity(nullptr)
             , requiredSize(0) {
             if (vc.model_texture) {
@@ -77,9 +80,9 @@ class Visualiser : public ViewportExt {
         CUDATextureBuffer<float> *x_var;
         CUDATextureBuffer<float> *y_var;
         CUDATextureBuffer<float> *z_var;
+        bool has_x, has_y, has_z;
         std::shared_ptr<Entity> entity;
         unsigned int requiredSize;  //  Ideally this needs to be threadsafe, but if we make it atomic stuff fails to build
-        static unsigned int instanceCounter;
     };
 
  public:
@@ -108,8 +111,11 @@ class Visualiser : public ViewportExt {
      * @param agent_name Name of the affected agent
      * @param state_name Name of the affected agent state
      * @param vc visualisation config settings for the affected agent state
+     * @param has_x Specify whether we require a tex buffer for location_x
+     * @param has_y Specify whether we require a tex buffer for location_y
+     * @param has_z Specify whether we require a tex buffer for location_z
      */
-    void addAgentState(const std::string &agent_name, const std::string &state_name, const AgentStateConfig &vc);
+    void addAgentState(const std::string &agent_name, const std::string &state_name, const AgentStateConfig &vc, bool has_x, bool has_y, bool has_z);
     /**
      * This notifies the render thread that an agent's texture buffers require resizing
      * @param agent_name Name of the affected agent


### PR DESCRIPTION
This also depends on a patch to main fgpu2 library: https://github.com/FLAMEGPU/FLAMEGPU2_dev/pull/464

Texture buffers are now requested explicitly, so it should correctly support a user only passing one coordinate out of x,y,z. (Unbound buffers should always return 0 within a shader).


Closes #35