### PR TITLE
Simulation speed display and limiter

### DIFF
--- a/include/FLAMEGPU_Visualisation.h
+++ b/include/FLAMEGPU_Visualisation.h
@@ -52,6 +52,12 @@ class FLAMEGPU_Visualisation {
     void updateAgentStateBuffer(const char *agent_name, const char *state_name, const unsigned int buffLen, float *d_x, float *d_y, float *d_z);
     Visualiser *vis = nullptr;
     LockHolder *lock = nullptr;
+    /**
+     * If non-0, limits the number of simulation steps per second, by blocking the return of releaseMutex
+     * Blocking whilst the mutex was held, would block visualisation updates as that also uses the mutex
+     * The actual value is the number of ms per step
+     */
+    unsigned int step_ms;
 };
 
 #endif  // INCLUDE_FLAMEGPU_VISUALISATION_H_

--- a/include/config/ModelConfig.h
+++ b/include/config/ModelConfig.h
@@ -102,6 +102,11 @@ struct ModelConfig {
      */
     bool stepVisible;
     /**
+     * The number of simulation steps to execute per second
+     * A value of 0 is treated as unlimited
+     */
+    unsigned int stepsPerSecond = 0;
+    /**
      * Store of static models to be rendered in visualisation
      */
     std::list<std::shared_ptr<StaticModel>> staticModels;

--- a/src/FLAMEGPU_Visualisation.cpp
+++ b/src/FLAMEGPU_Visualisation.cpp
@@ -12,7 +12,9 @@ class LockHolder {
 };
 
 FLAMEGPU_Visualisation::FLAMEGPU_Visualisation(const ModelConfig& modelcfg)
-    : vis(new Visualiser(modelcfg)) { }
+    : vis(new Visualiser(modelcfg))
+    // int division is fine, sleeping less is better than sleeping more, system interrupts already mean sleep might be longer
+    , step_ms(modelcfg.stepsPerSecond ? 1000 / modelcfg.stepsPerSecond : 0) { }
 FLAMEGPU_Visualisation::~FLAMEGPU_Visualisation() {
     if (vis)
         delete vis;
@@ -53,5 +55,18 @@ void FLAMEGPU_Visualisation::releaseMutex() {
     if (lock) {
         delete lock;
         lock = nullptr;
+    }
+    // Block the return to hit the desired steps per second
+    if (step_ms) {
+        static unsigned int last_ticks;
+        const unsigned int new_ticks = SDL_GetTicks();
+        const int sleep_time = step_ms - (new_ticks - last_ticks);
+        if (sleep_time > 0) {
+            SDL_Delay(sleep_time);
+            last_ticks += step_ms;
+        } else if (last_ticks < new_ticks) {
+            // Edge case where a step takes longer than step_ms
+            last_ticks = new_ticks;
+        }
     }
 }

--- a/src/Visualiser.cpp
+++ b/src/Visualiser.cpp
@@ -386,7 +386,6 @@ void Visualiser::requestBufferResizes(const std::string &agent_name, const std::
 void Visualiser::updateAgentStateBuffer(const std::string &agent_name, const std::string &state_name, const unsigned buffLen, float *d_x, float *d_y, float *d_z) {
     std::pair<std::string, std::string> namepair = { agent_name, state_name };
     auto &as = agentStates.at(namepair);
-
     //  Copy Data
     if ((as.x_var && as.x_var->elementCount >= buffLen) ||
         (as.y_var && as.y_var->elementCount >= buffLen) ||
@@ -587,6 +586,7 @@ void Visualiser::handleKeypress(SDL_Keycode keycode, int /*x*/, int /*y*/) {
             pause_guard = nullptr;
         } else {
             pause_guard = new std::lock_guard<std::mutex>(render_buffer_mutex);
+            stepsPerSecond = 0.0f;
         }
         break;
     case SDLK_l:

--- a/src/Visualiser.h
+++ b/src/Visualiser.h
@@ -286,13 +286,26 @@ class Visualiser : public ViewportExt {
      */
     std::shared_ptr<Text> fpsDisplay;
     /**
-     * The object which renders step counter text to the visualisation
+     * The objects which renders step counter and steps per second text to the visualisation
      */
-    std::shared_ptr<Text> stepDisplay;
+    std::shared_ptr<Text> stepDisplay, spsDisplay;
     /**
      * When user updates stepCount it is stored here, as we cannot update the OpenGL texture from a thread which doesn't hold the context
      */
-    unsigned int stepCount = 0;
+    unsigned int previousStepTime = 0, currentStepTime, stepCount = 0, lastStepCount = 0;
+    /**
+     * Steps equivalent of FPS.
+     * Calculated in the wrong thread, so we update it whenever FPS updates
+     */
+    double stepsPerSecond;
+    /**
+     * Pressing F8 changes whether FPS is displayed in the bottom corner, according to this schema
+     * The list is iterated in reverse (2, 1, 0)
+     * 0 = Display none
+     * 1 = Display step count only
+     * 2 = Display step count, sps, fps
+     */
+    unsigned int fpsStatus = 2;
     /**
      * User defined model configuration options
      */

--- a/src/util/Resources.h
+++ b/src/util/Resources.h
@@ -25,7 +25,6 @@ class Resources {
      * Returns true if path is a valid resource path
      */
     static bool exists(const std::string &path);
-
 };
 
 #endif  // SRC_UTIL_RESOURCES_H_


### PR DESCRIPTION
Adds "steps per second" (sps) to ui in bottom right corner, alongside fps/step count.
Changes F8 behaviour to iterate between 3 states, new state displays only step count.
Adds simulation speed limit to `ModelVis`.

Closes #12 
Closes https://github.com/FLAMEGPU/FLAMEGPU2_dev/issues/442